### PR TITLE
Revert to using setuptools backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,5 +106,5 @@ exclude = ["lmoments3.tests*"]
 VCS = "git"
 style = "pep440"
 versionfile_source = "lmoments3/_version.py"
-versionfile_build = "lmoments3/_version.py"
+versionfile_build = "_version.py"
 tag_prefix = "v"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ py_version = 38
 append_only = true
 
 [tool.setuptools.dynamic]
-version = {attr = "myproject.__version__"}
+version = {attr = "lmoments3.__version__"}
 
 [tool.setuptools.packages.find]
 where = ["lmoments3"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "versioneer[toml]", "numpy", "scipy"]
+requires = ["setuptools", "versioneer[toml]"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -95,16 +95,9 @@ profile = "black"
 py_version = 38
 append_only = true
 
-[tool.setuptools.dynamic]
-version = {attr = "lmoments3.__version__"}
-
-[tool.setuptools.packages.find]
-where = ["lmoments3"]
-exclude = ["lmoments3.tests*"]
-
 [tool.versioneer]
 VCS = "git"
 style = "pep440"
 versionfile_source = "lmoments3/_version.py"
-versionfile_build = "_version.py"
+versionfile_build = "lmoments3/_version.py"
 tag_prefix = "v"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools", "versioneer[toml]"]
+requires = ["setuptools", "versioneer[toml]", "numpy", "scipy"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["flit_core >=3.8,<4", "versioneer[toml]"]
-build-backend = "flit_core.buildapi"
+requires = ["setuptools", "versioneer[toml]"]
+build-backend = "setuptools.build_meta"
 
 [project]
 name = "lmoments3"
@@ -94,6 +94,13 @@ exclude = [".*", "conda-recipe/**", "conda-build.ps1", "docs/build/**"]
 profile = "black"
 py_version = 38
 append_only = true
+
+[tool.setuptools.dynamic]
+version = {attr = "myproject.__version__"}
+
+[tool.setuptools.packages.find]
+where = ["lmoments3"]
+exclude = ["lmoments3.tests*"]
 
 [tool.versioneer]
 VCS = "git"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+from setuptools import setup
+
+import versioneer
+
+setup(
+    name="lmoments3",
+    packages=["lmoments3"],
+    version=versioneer.get_version(),
+    cmdclass=versioneer.get_cmdclass(),
+)


### PR DESCRIPTION
So it turns out that setuptools is absolutely needed as a backend with versioneer for the moment. Lessons were learned.