### PR TITLE
Allow execution of code section for convergence - support Python 3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python${{ matrix.python-version }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+version 1.0.7 (unreleased)
+--------------------------
+- Fix algorithm convergence for the `kappa` distribution.
+
 version 1.0.6 (2023-07-06)
 --------------------------
 - Adopted `pyproject.toml` with `setuptools` backend for build configuration (PEP 517 and PEP 621)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 version 1.0.7 (unreleased)
 --------------------------
 - Fix algorithm convergence for the `kappa` distribution.
+- Added Python 3.12 to the test suite and supported versions.
 
 version 1.0.6 (2023-07-06)
 --------------------------

--- a/lmoments3/distr.py
+++ b/lmoments3/distr.py
@@ -655,13 +655,14 @@ class KappaGen(LmomDistrMixin, scipy.stats.rv_continuous):
                 if DIST < Xdist:
                     Success = 1
                     break
-                else:
-                    pass
-                    # FIXME: The following variables are undefined
-                    # DEL1 = 0.5 * DEL1
-                    # DEL2 = 0.5 * DEL2
-                    # G = XG - DEL1
-                    # H = XH - DEL2
+                elif it > 1:
+                    # These variables are only defined on a second iteration
+                    # The Original fortran code sets them to 0
+                    # but the comments imply that it is only for compiler checks
+                    DEL1 = 0.5 * DEL1
+                    DEL2 = 0.5 * DEL2
+                    G = XG - DEL1
+                    H = XH - DEL2
 
             if Success == 0:
                 raise Exception("Failed to converge")

--- a/lmoments3/distr.py
+++ b/lmoments3/distr.py
@@ -659,10 +659,10 @@ class KappaGen(LmomDistrMixin, scipy.stats.rv_continuous):
                     # These variables are only defined on a second iteration
                     # The Original fortran code sets them to 0
                     # but the comments imply that it is only for compiler checks
-                    DEL1 = 0.5 * DEL1
-                    DEL2 = 0.5 * DEL2
-                    G = XG - DEL1
-                    H = XH - DEL2
+                    DEL1 = 0.5 * DEL1  # noqa F821
+                    DEL2 = 0.5 * DEL2  # noqa F821
+                    G = XG - DEL1  # noqa F821
+                    H = XH - DEL2  # noqa F821
 
             if Success == 0:
                 raise Exception("Failed to converge")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ classifiers = [
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
   "Topic :: Scientific/Engineering :: Mathematics"
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,8 @@ target-version = [
   "py38",
   "py39",
   "py310",
-  "py311"
+  "py311",
+  "py312"
 ]
 extend-exclude = 'lmoments3/_version.py'
 


### PR DESCRIPTION
Fixes #16.

From my reading of the R implementation, the commented out section is not supposed to be attainable on the first pass. The R code initializes the variables (`DEL1, DEL2, XG, XH`) to zero, but with a comment saying "to assuage compilers that warn that variables 'might be used uninitialized'". I thus assume that we can use a pythonic solution to the same problem. 

The variables are first set at the end of the first iteration, thus the `it > 1` check.

CAUTION: I know Python, I know how to read Fortran, but I do NOT claim to understands the maths going on here.

@TC-FF, please take a look at this and confirm if this should work.