### PR TITLE
Avoid inplace sort of input of lmom_ratios

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+version 1.0.7 (unreleased)
+--------------------------
+- Avoid inplace modifications of input arrays in ``lmom_ratios``.
+
 version 1.0.6 (2023-07-06)
 --------------------------
 - Adopted `pyproject.toml` with `setuptools` backend for build configuration (PEP 517 and PEP 621)

--- a/lmoments3/__init__.py
+++ b/lmoments3/__init__.py
@@ -86,7 +86,7 @@ def _samlmularge(x, nmom=5):
     try:
         x = np.asarray(x, dtype=np.float64)
         n = len(x)
-        x.sort()
+        x = np.sort(x)
     except ValueError:
         raise ValueError("Input data to estimate L-moments must be numeric.")
 
@@ -142,7 +142,7 @@ def _samlmusmall(x, nmom=5):
     try:
         x = np.asarray(x, dtype=np.float64)
         n = len(x)
-        x.sort()
+        x = np.sort(x)
     except ValueError:
         raise ValueError("Input data to estimate L-moments must be numeric.")
 

--- a/lmoments3/distr.py
+++ b/lmoments3/distr.py
@@ -48,7 +48,7 @@ class LmomDistrMixin:
         """When overriding, *shapes can be replaced by the actual distribution's shape parameter(s), if any."""
         raise NotImplementedError
 
-    def lmom_fit(self, data=[], lmom_ratios=[]):
+    def lmom_fit(self, data=None, lmom_ratios=None):
         """Fit the distribution function to the given data or given L-moments.
 
         :param data: Data to use in calculating the distribution parameters
@@ -59,11 +59,11 @@ class LmomDistrMixin:
         :rtype: :class:`OrderedDict`
         """
         n_min = self.numargs + 2
-        if len(data) > 0:
+        if data is not None:
             if len(data) <= n_min:
                 raise ValueError(f"At least {n_min} data points must be provided.")
             lmom_ratios = lm.lmom_ratios(data, nmom=n_min)
-        elif not lmom_ratios:
+        elif lmom_ratios is None:
             raise Exception("Either `data` or `lmom_ratios` must be provided.")
         elif len(lmom_ratios) < n_min:
             raise ValueError(f"At least {n_min} number of L-moments must be provided.")

--- a/lmoments3/tests/test_lmoments.py
+++ b/lmoments3/tests/test_lmoments.py
@@ -1,5 +1,6 @@
 import unittest
 
+import numpy as np
 from numpy.testing import assert_almost_equal
 
 import lmoments3 as lm
@@ -9,10 +10,12 @@ from lmoments3.tests import DistributionTestCase
 
 class TestLmoments(unittest.TestCase):
     def test_samlmu(self):
-        testdata = [2.0, 3.0, 4.0, 2.4, 5.5, 1.2, 5.4, 2.2, 7.1, 1.3, 1.5]
+        testdata = np.array([2.0, 3.0, 4.0, 2.4, 5.5, 1.2, 5.4, 2.2, 7.1, 1.3, 1.5])
         expected = [3.23636364, 1.14181818, 0.27388535, 0.02335456, -0.04246285]
         result = lm.lmom_ratios(testdata)
         assert_almost_equal(result, expected)
+        # Ensure input was not modified by `lmom_ratios`.
+        assert all(testdata[-3:] == [7.1, 1.3, 1.5])
 
     def test_aic(self):
         data = [


### PR DESCRIPTION
- `lmoments3.lmom_ratios` was applying in-place sorting to its input (`x.sort()`), changed it to copy : `x = np.sort(x)`.
- Modified defaults of `LmomDistrMixin.lmom_fit` to avoid `[]`. 
- Added an assert in `lmom_ratios` test.

Fixes #15 and OpenHydrology/lmoments3#2.

The issue only happens when `np.asarray(x, dtype=np.float64)` encounters an object it does *not* need to cast as an array, i.e. an array of dtype `float64`. In all other cases there's an implicit copy. 